### PR TITLE
Shorter code for jscript named function expressions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,8 +12,7 @@ export default function ({ Plugin, types: t }) {
 
           return t.callExpression(
             t.functionExpression(null, [], t.blockStatement([
-              t.toStatement(node),
-              t.returnStatement(node.id)
+              t.returnStatement(node)
             ])),
             []
           );


### PR DESCRIPTION
Since the node is initially a FunctionExpression, why convert it to a Statement when we can just return it immediately?

I reviewed the problems with named function expressions in IE8, and I believe this simplification is safe: http://kiro.me/blog/nfe_dilemma.html