### PR TITLE
Don't wrap named function expressions unnecessarily.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,9 +6,24 @@ export default function ({ Plugin, types: t }) {
     
     visitor: {
       FunctionExpression: {
-        exit(node) {
+        exit(node, parent) {
           if (!node.id) return;
           node._ignoreUserWhitespace = true;
+
+          if (t.isReturnStatement(parent)) {
+            var parentScopeHasNoBindings = !this.scope.parent ||
+              Object.keys(this.scope.parent.bindings).length === 0;
+
+            if (parentScopeHasNoBindings) {
+              // If this FunctionExpression is being returned from a scope
+              // that has no bindings, then there is no need to wrap it
+              // with an IIFE, because it's fine if the function name
+              // leaks into that empty scope (as it will in IE8). This
+              // clause is mostly to keep the FunctionExpression generated
+              // below from being transformed again by this plugin.
+              return;
+            }
+          }
 
           return t.callExpression(
             t.functionExpression(null, [], t.blockStatement([


### PR DESCRIPTION
This fixes the problem described [here](https://github.com/babel-plugins/babel-plugin-jscript/pull/1#issuecomment-123900644).