### PR TITLE
Go back to declaring a function and returning its name :(

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,28 +6,14 @@ export default function ({ Plugin, types: t }) {
     
     visitor: {
       FunctionExpression: {
-        exit(node, parent) {
+        exit(node) {
           if (!node.id) return;
           node._ignoreUserWhitespace = true;
 
-          if (t.isReturnStatement(parent)) {
-            var parentScopeHasNoBindings = !this.scope.parent ||
-              Object.keys(this.scope.parent.bindings).length === 0;
-
-            if (parentScopeHasNoBindings) {
-              // If this FunctionExpression is being returned from a scope
-              // that has no bindings, then there is no need to wrap it
-              // with an IIFE, because it's fine if the function name
-              // leaks into that empty scope (as it will in IE8). This
-              // clause is mostly to keep the FunctionExpression generated
-              // below from being transformed again by this plugin.
-              return;
-            }
-          }
-
           return t.callExpression(
             t.functionExpression(null, [], t.blockStatement([
-              t.returnStatement(node)
+              t.toStatement(node),
+              t.returnStatement(node.id)
             ])),
             []
           );


### PR DESCRIPTION
Really sorry to create all this unnecessary work for you, but after working with this code in more depth, I've become convinced the only viable approach is the original approach, because IE8 simply can't handle named function expressions at all.

The final, unavoidable gotcha was that, given this function definition:
```js
var foo = (function () {
  return function foo () {
    return foo;
  };
})();
```

the following assertion fails, if you can believe it:
```js
assert.strictEqual(foo(), foo);
```

The reason is that the `foo` function object that leaks into the IIFE scope (and thus the `foo` visible in the body of the innermost function) is not even the same object as the function object returned from the IIFE!

In particular, this causes `babelHelpers.classCallCheck` to fail during class instantiation, since `this.constructor` differs from the constructor function invoked by `new`.